### PR TITLE
Add article as test data for lacinka

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -1,9 +1,23 @@
 # Łacinka
 
-### Python 3 library for converting Belarusian cyrillic case to latin
+Python 3 library for converting Belarusian cyrillic case to latin
 
-Setup package and run tests:
+### Create Python virtual enviroment
+
+Ensure venv is installed:
+```
+apt-get install python3-venv
+```
+
+In the project folder run:
+```
+python -m venv ./venv
+source ./venv/bin/activate
+```
+
+### Setup package and run tests:
 ```
 python setup.py develop
-py.test
+pip install -r requirements.txt
+pytest
 ```

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,1 +1,2 @@
 pytest
+mypy

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,2 +1,1 @@
 pytest
-mypy

--- a/python/tests/test_cyr_to_lat.py
+++ b/python/tests/test_cyr_to_lat.py
@@ -24,8 +24,6 @@ def read_json_data():
 def test_translate(test_data):
     if 'cyr_taras' in test_data:
         assert convert(test_data['cyr_taras'], Case.CYR_TARAS, Case.LAT) == test_data['lat']
-    elif 'cyr_nar' in test_data:
+    if 'cyr_nar' in test_data:
         assert convert(test_data['cyr_nar'], Case.CYR_NAR, Case.LAT) == test_data['lat']
-    else:
-        pytest.fail('test data has no Cyrillic text')
 

--- a/python/tests/test_cyr_to_lat.py
+++ b/python/tests/test_cyr_to_lat.py
@@ -7,12 +7,14 @@ from translit.cases import Case
 
 
 def read_json_data():
-    test_file_list = glob.glob('../tests/test_*.json')
+    test_file_list = glob.glob('../tests/*.json')
     all_test_cases = []
     for test_file in test_file_list:
         with open(test_file) as file:
             test_file_data = json.load(file)
             for test_case in test_file_data["tests"]:
+                if test_case.get("disabled", False):
+                    continue
                 test_case["name"] = test_file.split("/")[-1] + "#" + test_case.get("name")
                 all_test_cases.append(test_case)
     return all_test_cases
@@ -20,5 +22,10 @@ def read_json_data():
 
 @pytest.mark.parametrize("test_data", read_json_data(), ids=lambda data: data['name'])
 def test_translate(test_data):
-    assert convert(test_data['cyr_taras'], Case.CYR_TARAS, Case.LAT) == test_data['lat']
+    if 'cyr_taras' in test_data:
+        assert convert(test_data['cyr_taras'], Case.CYR_TARAS, Case.LAT) == test_data['lat']
+    elif 'cyr_nar' in test_data:
+        assert convert(test_data['cyr_nar'], Case.CYR_NAR, Case.LAT) == test_data['lat']
+    else:
+        pytest.fail('test data has no Cyrillic text')
 

--- a/python/translit/converters/translit_cyr_nar_to_lat.py
+++ b/python/translit/converters/translit_cyr_nar_to_lat.py
@@ -1,0 +1,6 @@
+from translit.converters import translit_cyr_taras_to_lat
+
+def convert(text: str) -> str:
+    # TODO: rework this to implement translation to Taraskievica first
+    # and then to lacinka.
+    return translit_cyr_taras_to_lat.convert(text)

--- a/python/translit/converters/translit_cyr_nar_to_lat.py
+++ b/python/translit/converters/translit_cyr_nar_to_lat.py
@@ -1,6 +1,6 @@
 from translit.converters import translit_cyr_taras_to_lat
 
-def convert(text: str) -> str:
+def convert(text):
     # TODO: rework this to implement translation to Taraskievica first
     # and then to lacinka.
     return translit_cyr_taras_to_lat.convert(text)

--- a/python/translit/converters/translit_cyr_taras_to_lat.py
+++ b/python/translit/converters/translit_cyr_taras_to_lat.py
@@ -6,7 +6,7 @@ import re
 # Since the script is optimized for Nasha Niva's requirements,
 # there are some places that will be reworked to make the converter more generic.
 
-def convert(text: str) -> str:
+def convert(text):
     conv = re.sub(
         # Match any single character that is not one of the listed Cyrillic letters.
         r'([^абвгдеёжзийклмнопрстуфхцчшщъыьэюяіў])' +

--- a/python/translit/converters/translit_cyr_taras_to_lat.py
+++ b/python/translit/converters/translit_cyr_taras_to_lat.py
@@ -6,7 +6,7 @@ import re
 # Since the script is optimized for Nasha Niva's requirements,
 # there are some places that will be reworked to make the converter more generic.
 
-def convert(text):
+def convert(text: str) -> str:
     conv = re.sub(
         # Match any single character that is not one of the listed Cyrillic letters.
         r'([^абвгдеёжзийклмнопрстуфхцчшщъыьэюяіў])' +
@@ -46,10 +46,10 @@ def convert(text):
     conv = conv.replace('ъю', 'ju')
     conv = conv.replace('ъи', 'ji')
     conv = conv.replace('ї', 'ji')
-    conv = conv.replace(' я', '&nbsp;ja')
-    conv = conv.replace(' е', '&nbsp;je')
-    conv = conv.replace(' ё', '&nbsp;jo')
-    conv = conv.replace(' ю', '&nbsp;ju')
+    conv = conv.replace(' я', ' ja')
+    conv = conv.replace(' е', ' je')
+    conv = conv.replace(' ё', ' jo')
+    conv = conv.replace(' ю', ' ju')
     conv = conv.replace('&rsquo;я', 'ja')
     conv = conv.replace('&rsquo;е', 'je')
     conv = conv.replace('&rsquo;ё', 'jo')

--- a/python/translit/engine.py
+++ b/python/translit/engine.py
@@ -1,12 +1,10 @@
 from translit.cases import Case
 from translit.converters import translit_cyr_taras_to_lat, translit_cyr_nar_to_lat
 
-from collections.abc import Callable, Mapping
-
 """
 Converter functions map
 """
-converters: Mapping[str, Callable[[str], str]] = {
+converters = {
     Case.CYR_TARAS + "_TO_" + Case.LAT: translit_cyr_taras_to_lat.convert,
     Case.CYR_NAR + "_TO_" + Case.LAT: translit_cyr_nar_to_lat.convert,
 }

--- a/python/translit/engine.py
+++ b/python/translit/engine.py
@@ -1,13 +1,15 @@
 from translit.cases import Case
-from translit.converters.translit_cyr_taras_to_lat import convert as convert_cyr_taras_to_lat
+from translit.converters import translit_cyr_taras_to_lat, translit_cyr_nar_to_lat
+
+from collections.abc import Callable, Mapping
 
 """
 Converter functions map
 """
-converters = {
-    Case.CYR_TARAS + "_TO_" + Case.LAT: convert_cyr_taras_to_lat,
+converters: Mapping[str, Callable[[str], str]] = {
+    Case.CYR_TARAS + "_TO_" + Case.LAT: translit_cyr_taras_to_lat.convert,
+    Case.CYR_NAR + "_TO_" + Case.LAT: translit_cyr_nar_to_lat.convert,
 }
-
 
 def convert(text, source_case, target_case):
     """

--- a/tests/lacinka_buduchynja_article.json
+++ b/tests/lacinka_buduchynja_article.json
@@ -1,0 +1,202 @@
+{
+    "name": "Article https://palatno.media/bielaruskaja-lacinka/",
+    "tests": [
+        {
+            "name": "Title",
+            "cyr_nar": "Чаму беларуская лацінка мае будучыню?",
+            "lat": "Čamu biełaruskaja łacinka maje budučyniu?"
+        },
+        {
+            "name": "Paragraph 1",
+            "cyr_nar": "Зусім нядаўна чыноўнікі ды «неабыякавыя грамадзяне» ў Беларусі ўзяліся за лацінку — беларускамоўныя подпісы лацінскім алфавітам, як правіла, геаграфічныя. Маўляў, усё вычысціць, бо «чужое». А ці чужое? Ці патрэбнае? Калі так — то навошта?",
+            "lat": "Zusim niadaŭna čynoŭniki dy «nieabyjakavyja hramadzianie» ŭ Biełarusi ŭzialisia za łacinku — biełaruskamoŭnyja podpisy łacinskim ałfavitam, jak praviła, hieahrafičnyja. Maŭlaŭ, usio vyčyścić, bo «čužoje». A ci čužoje? Ci patrebnaje? Kali tak — to navošta?"
+        },
+        {
+            "name": "Paragraph 2",
+            "cyr_nar": "Гэты артыкул можна прачытаць беларускай лацінкай.",
+            "lat": "Hety artykuł možna pračytać biełaruskaj łacinkaj."
+        },
+        {
+            "name": "Paragraph 3",
+            "cyr_nar": "Гісторыя беларускай лацінкі — асобны лінгвістычны раман, а мо і дэтэктыў. Усе мы са школы звыкліся ўспрымаць беларускую мову на кірыліцы, але яшчэ сто год таму ў Заходняй Беларусі выданні па-беларуску выходзілі прыкладна 50 на 50 — лацінкай і кірыліцай. Больш таго: сёння беларусы Падляшша збольшага карыстаюцца лацінкай. Гэта традыцыя, а яшчэ — практычна, калі твая асноўная раскладка на тэлефоне польская.",
+            "lat": "Historyja biełaruskaj łacinki — asobny linhvistyčny raman, a mo i detektyŭ. Usie my sa škoły zvyklisia ŭsprymać biełaruskuju movu na kirylicy, ale jašče sto hod tamu ŭ Zachodniaj Biełarusi vydańni pa-biełarusku vychodzili prykładna 50 na 50 — łacinkaj i kirylicaj. Bolš taho: siońnia biełarusy Padlašša zbolšaha karystajucca łacinkaj. Heta tradycyja, a jašče — praktyčna, kali tvaja asnoŭnaja raskładka na telefonie polskaja."
+        },
+        {
+            "name": "Paragraph 4",
+            "cyr_nar": "Але, магчыма, гэта ўсяго толькі рэха мінулага? «Састарэлыя файлы» з моўнага софту?.. Разбяромся.",
+            "lat": "Ale, mahčyma, heta ŭsiaho tolki recha minułaha? «Sastarełyja fajły» z moŭnaha softu?.. Raźbiaromsia."
+        },
+        {
+            "name": "Paragraph 5",
+            "cyr_nar": "Мова гучыць таксама, алфавіт — змяняецца",
+            "lat": "Mova hučyć taksama, ałfavit — źmianiajecca"
+        },
+        {
+            "name": "Paragraph 6",
+            "disabled": "zjaŭlacca or źjaŭlacca",
+            "cyr_nar": "З чаго ўсё пачалося? У кожнага народа адметная мова, а вось алфавіты збольшага стандартызаваныя. Чэхі, немцы, іспанцы ці фіны карыстаюцца лацінскім алфавітам, хоць гавораць па-рознаму. Куды менш народаў з адметнымі — нацыянальнымі алфавітамі: грузіны, армяне, яўрэі, кітайцы, японцы… З аднаго боку, такі кейс адметны, з іншага — вывучаць гэтыя мовы ўдвая складаней.",
+            "lat": "Z čaho ŭsio pačałosia? U kožnaha naroda admietnaja mova, a voś ałfavity zbolšaha standartyzavanyja. Čechi, niemcy, ispancy ci finy karystajucca łacinskim ałfavitam, choć havorać pa-roznamu. Kudy mienš narodaŭ z admietnymi — nacyjanalnymi ałfavitami: hruziny, armianie, jaŭrei, kitajcy, japoncy… Z adnaho boku, taki kiejs supieradmietny, z inšaha — vyvučać hetyja movy ŭdvaja składaniej."
+        },
+        {
+            "name": "Paragraph 7",
+            "cyr_nar": "На мове найперш гавораць, пасля пішуць. І алфавіт — гэта нібы вопратка для моўнай сістэмы, якая ўжо склалася. Ён — другасны і часам змяняецца. Так, манголы мелі некалі сваё вертыкальнае пісьмо, пакуль СССР не навязаў ім кірылічнае пісьмо. Туркі стагоддзямі пісалі арабіцай, але Атацюрк 100 год таму ўвёў лацініцу. Мова гучыць таксама, як і гучала, алфавіт — змяняецца.",
+            "lat": "Na movie najpierš havorać, paśla pišuć. I ałfavit — heta niby vopratka dla moŭnaj sistemy, jakaja ŭžo skłałasia. Jon — druhasny i časam źmianiajecca. Tak, manhoły mieli niekali svajo viertykalnaje piśmo, pakul SSSR nie naviazaŭ im kiryličnaje piśmo. Turki stahoddziami pisali arabicaj, ale Ataciurk 100 hod tamu ŭvioŭ łacinicu. Mova hučyć taksama, jak i hučała, ałfavit — źmianiajecca."
+        },
+        {
+            "name": "Paragraph 8",
+            "cyr_nar": "Jaśko haspadar z pad Wilni і Maciej Buraczok",
+            "lat": "Jaśko haspadar z pad Wilni i Maciej Buraczok"
+        },
+        {
+            "name": "Paragraph 9",
+            "cyr_nar": "Першым пісьмовым алфавітам у Беларусі была кірыліца яшчэ з часоў Полацкага княства — 1000 год таму. Лагічна: хрысціянства прынялі з Візантыі, а ў нагрузку — царкоўнаславянская мова плюс кірыліца. Зрэшты, Заходнюю Беларусь Ягайла хрысціў на 400 год пазней, таму для нашых шматлікіх каталіцкіх продкаў з Гродзеншчыны першым алфавітам была лацініца.",
+            "lat": "Pieršym piśmovym ałfavitam u Biełarusi była kirylica jašče z časoŭ Połackaha kniastva — 1000 hod tamu. Łahična: chryścijanstva pryniali ź Vizantyi, a ŭ nahruzku — carkoŭnasłavianskaja mova plus kirylica. Zrešty, Zachodniuju Biełaruś Jahajła chryściŭ na 400 hod paźniej, tamu dla našych šmatlikich katalickich prodkaŭ z Hrodzienščyny pieršym ałfavitam była łacinica."
+        },
+        {
+            "name": "Paragraph 10",
+            "cyr_nar": "Алфавіт быў часткай дзяржаўнай палітыкі, як і мова. З той папраўкай, што гаворка не пра беларускую, рускую і польскую, а пра лацінскую і царкоўнаславянскую, бо менавіта канфесіі (каталіцтва/праваслаўе) пазначалі межы цывілізацый. Землі Беларусі — на мяжы паміж Захадам і Усходам, таму такая дваістасць была закладзеная яшчэ шмат сотняў год таму.",
+            "lat": "Ałfavit byŭ častkaj dziaržaŭnaj palityki, jak i mova. Z toj papraŭkaj, što havorka nie pra biełaruskuju, ruskuju i polskuju, a pra łacinskuju i carkoŭnasłavianskuju, bo mienavita kanfiesii (katalictva/pravasłaŭje) paznačali miežy cyvilizacyj. Ziemli Biełarusi — na miažy pamiž Zachadam i Uschodam, tamu takaja dvaistaść była zakładzienaja jašče šmat sotniaŭ hod tamu."
+        },
+        {
+            "name": "Paragraph 11",
+            "disabled": "We should handle roman numerals",
+            "cyr_nar": "Лацінская транслітарацыя беларускай мовы найлепш прыжылася на Віленшчыне, Гродзеншчыне, Міншчыне. Тут у ХІХ стагоддзі акурат і нарадзіўся беларускі нацыянальны праект з Паўстання Каліноўскага і вершаў Багушэвіча. Абодва пісалі і падпісваліся лацінкай: Jaśko haspadar z pad Wilni ды Maciej Buraczok. Алфавіт «Мужыцкай Праўды» і «Дудкі Беларускай» — лацінка.",
+            "lat": "Łacinskaja tranślitaracyja biełaruskaj movy najlepš pryžyłasia na Vilenščynie, Hrodzienščynie, Minščynie. Tut u XIX stahodździ akurat i naradziŭsia biełaruski nacyjanalny prajekt z Paŭstańnia Kalinoŭskaha i vieršaŭ Bahuševiča. Abodva pisali i padpisvalisia łacinkaj: Jaśko haspadar z pad Wilni dy Maciej Buraczok. Ałfavit «Mužyckaj Praŭdy» i «Dudki Biełaruskaj» — łacinka."
+        },
+        {
+            "name": "Paragraph 12",
+            "cyr_nar": "Кастусь Каліноўскі — адзін з аўтараў беларускага праекта як такога, яшчэ і прапагандыст нашай лацінкі. Сучасны арт",
+            "lat": "Kastuś Kalinoŭski — adzin z aŭtaraŭ biełaruskaha prajekta jak takoha, jašče i prapahandyst našaj łacinki. Sučasny art"
+        },
+        {
+            "name": "Paragraph 13",
+            "cyr_nar": "Ад «Нашай Нівы» да Сталіна",
+            "lat": "Ad «Našaj Nivy» da Stalina"
+        },
+        {
+            "name": "Paragraph 14",
+            "cyr_nar": "Дзве версіі газеты «Наша Ніва» — кірыліцай і лацінкай",
+            "lat": "Dźvie viersii haziety «Naša Niva» — kirylicaj i łacinkaj"
+        },
+        {
+            "name": "Paragraph 15",
+            "disabled": "We should handle roman numerals",
+            "cyr_nar": "Дыскусія пра алфавіт для беларускай мовы пачалася на зломе ХІХ і ХХ стагоддзяў. Як правіла, дзеячы з праваслаўным бэкграўндам выбіралі кірыліцу, з каталіцкім — за лацінку. «Наша Ніва» ад 1906 году выходзіла і так, і гэтак, у дзвюх версіях, каб ахапіць максімум чытачоў. Гэта ўспрымалася гэтаксама, як зараз сайты з расійскай і беларускай версіямі — для камфорту.",
+            "lat": "Dyskusija pra ałfavit dla biełaruskaj movy raspačałasia na złomie XIX i XX stahodździaŭ. Jak praviła, dziejačy z pravasłaŭnym bekhraŭndam vybirali kirylicu, z katalickim — za łacinku. «Naša Niva» ad 1906 hodu vychodziła i tak, i hetak, u dźviuch viersijach, kab achapić maksimum čytačoŭ. Heta ŭsprymałasia hetaksama, jak zaraz sajty z rasijskaj i biełaruskaj viersijami — dla kamfortu."
+        },
+        {
+            "name": "Paragraph 16",
+            "cyr_nar": "Дарэчы, нядаўна сучасная «Наша Ніва» запусціла версію сайта беларускай лацінкай.",
+            "lat": "Darečy, niadaŭna sučasnaja «Naša Niva» zapuściła viersiju sajta biełaruskaj łacinkaj."
+        },
+        {
+            "name": "Paragraph 17",
+            "cyr_nar": "Дакументацыя Беларускай Народнай Рэспублікі збольшага ўжо на кірыліцы, але безліч выданняў таго часу — лацінка. Лагічна: БНР прэтэндавала на шырокія тэрыторыі на ўсходзе, ажно з кавалкамі Браншчыны і Смаленшчыны. У дадатак, вялікая колькасць дзеячаў — былыя расійскія афіцэры і чыноўнікі. Беларуская мова — окей, але ані сама мова, ані алфавіт не былі ўнармаваныя і юрыдычна замацаваныя.",
+            "lat": "Dakumientacyja Biełaruskaj Narodnaj Respubliki zbolšaha ŭžo na kirylicy, ale bieźlič vydańniaŭ taho času — łacinka. Łahična: BNR pretendavała na šyrokija terytoryi na ŭschodzie, ažno z kavałkami Branščyny i Smalenščyny. U dadatak, vialikaja kolkaść dziejačaŭ — byłyja rasijskija aficery i čynoŭniki. Biełaruskaja mova — okiej, ale ani sama mova, ani ałfavit nie byli ŭnarmavanyja i jurydyčna zamacavanyja."
+        },
+        {
+            "name": "Paragraph 18",
+            "cyr_nar": "Карты склаліся ў часы БССР. Пасля кароткай адлігі і нават дыскусій пра лацінку ў нацыянальных рэспубліках усё адназначна вырашылася на карысць кірыліцы пры Сталіне. Нават казахскую хуценька перавялі з лацінкі на кірыліцу, хоць абодва алфавіты не ёсць традыцыйнымі для таго рэгіёна.",
+            "lat": "Karty skłalisia ŭ časy BSSR. Paśla karotkaj adlihi i navat dyskusij pra łacinku ŭ nacyjanalnych respublikach usio adnaznačna vyrašyłasia na karyść kirylicy pry Stalinie. Navat kazachskuju chucieńka pieraviali z łacinki na kirylicu, choć abodva ałfavity nie jość tradycyjnymi dla taho rehijona."
+        },
+        {
+            "name": "Paragraph 19",
+            "cyr_nar": "Каляндар, выдадзены Вацлавам Ластоўскім на беларускай лацінцы",
+            "lat": "Kalandar, vydadzieny Vacłavam Łastoŭskim na biełaruskaj łacincy"
+        },
+        {
+            "name": "Paragraph 20",
+            "cyr_nar": "Лацінка захавалася ў Заходняй Беларусі, дзе «акапаўся» нацыянальны рух, але — зразумела — не меў палітычнай улады. Творы Станкевіча, Ластоўскага, Купалы і Коласа, а таксама беларускія календары і газеты выходзілі там на абодвух алфавітах. Пасля 1939 года «канчатковае вырашэнне пытання лацінкі» дабралася і сюды… Больш таго: старыя выданні лацінкай, аўтары якіх былі рэпрэсаваныя, мэтава знішчаліся. Сёння гэта ўжо рарытэты.",
+            "lat": "Łacinka zachavałasia ŭ Zachodniaj Biełarusi, dzie «akapaŭsia» nacyjanalny ruch, ale — zrazumieła — nie mieŭ palityčnaj ułady. Tvory Stankieviča, Łastoŭskaha, Kupały i Kołasa, a taksama biełaruskija kalendary i haziety vychodzili tam na abodvuch ałfavitach. Paśla 1939 hoda «kančatkovaje vyrašeńnie pytańnia łacinki» dabrałasia i siudy… Bolš taho: staryja vydańni łacinkaj, aŭtary jakich byli represavanyja, metava źniščalisia. Siońnia heta ŭžo rarytety."
+        },
+        {
+            "name": "Paragraph 21",
+            "disabled": "We should handle roman numerals",
+            "cyr_nar": "Так выглядае верш Янкі Купалы, выдадзены лацінкай на пачатку ХХ стагоддзя",
+            "lat": "Tak vyhladaje vierš Janki Kupały, vydadzieny łacinkaj na pačatku XX stahodździa"
+        },
+        {
+            "name": "Paragraph 22",
+            "cyr_nar": "«Акно магчымасцей» пры немцах і БССР як lacinka-free state",
+            "lat": "«Akno mahčymaściej» pry niemcach i BSSR jak lacinka-free state"
+        },
+        {
+            "name": "Paragraph 23",
+            "disabled": "zjaŭlacca or źjaŭlacca",
+            "cyr_nar": "Апошняе «акно магчымасцей» для беларускай лацінкі — як ні парадаксальна — часы нямецкай акупацыі 1941-1944. Тады, апроч газет і часопісаў, упершыню з’явіўся пласт справаводства беларускай лацінкай: пашпарты, квіткі, даведкі, пячаткі…",
+            "lat": "Apošniaje «akno mahčymaściej» dla biełaruskaj łacinki — jak ni paradaksalna — časy niamieckaj akupacyi 1941-1944. Tady, aproč haziet i časopisaŭ, upieršyniu zjaviŭsia płast dakumientaabarotu (!) biełaruskaj łacinkaj: pašparty, kvitki, daviedki, piačatki…"
+        },
+        {
+            "name": "Paragraph 24",
+            "cyr_nar": "Не таму, што немцам карцела навязаць беларусам лацінку: ім было ўсё роўна. Прычына: такі варыянт быў зразумелы жыхарам Заходняй і Цэнтральнай Беларусі.",
+            "lat": "Nie tamu, što niemcam karcieła naviazać biełarusam łacinku: im było ŭsio roŭna. Pryčyna: taki varyjant byŭ zrazumieły žycharam Zachodniaj i Centralnaj Biełarusi."
+        },
+        {
+            "name": "Paragraph 25",
+            "cyr_nar": "Беларуская лацінка ў справаводстве побач з нямецкай мовай. Ліда, 1942 год. Фота: Алесь Кіркевіч",
+            "lat": "Biełaruskaja łacinka ŭ spravavodstvie pobač ź niamieckaj movaj. Lida, 1942 hod. Fota: Aleś Kirkievič"
+        },
+        {
+            "name": "Paragraph 26",
+            "cyr_nar": "Паваенны БССР быў цалкам lacinka-free state. Гэта супала з русіфікацыяй краіны і набліжэннем граматыкі мовы да рускай. Лацінка бачылася як нешта састарэлае, буржуазнае і антысавецкае. Таму захавалася толькі як мова выданняў эміграцыі ў ЗША, ФРГ ці Вялікабрытаніі. Ды яшчэ спарадычна на Падляшшы — у сацыялістычнай Польшчы.",
+            "lat": "Pavajenny BSSR byŭ całkam lacinka-free state. Heta supała z rusifikacyjaj krainy i nabližeńniem hramatyki movy da ruskaj. Łacinka bačyłasia jak niešta sastarełaje, buržuaznaje i antysavieckaje. Tamu zachavałasia tolki jak mova vydańniaŭ emihracyi ŭ ZŠA, FRH ci Vialikabrytanii. Dy jašče sparadyčna na Padlaššy — u sacyjalistyčnaj Polščy."
+        },
+        {
+            "name": "Paragraph 27",
+            "cyr_nar": "У касцёле на Залатой Горцы ў Мінску шмат подпісаў беларускай лацінкай. Фота: Вікіпедыя",
+            "lat": "U kaściole na Załatoj Horcy ŭ Minsku šmat podpisaŭ biełaruskaj łacinkaj. Fota: Vikipiedyja"
+        },
+        {
+            "name": "Paragraph 28",
+            "cyr_nar": "Пачатак 1990-х — рэнесанс беларускай лацінкі. Размовы пра перавод дакументацыі ўжо не ідзе, але яе актыўна выкарыстоўваюць у касцёле. Таксама паўстае мода сярод нацыянальнай культурнай тусоўкі. Маё пакаленне, скажам, сутыкнулася з лацінкай праз «Pašpart hramadzianina N.R.M.» ды «Try čarapachi». Наступнае – праз Akute. Асобныя літаратурныя творы, як «Śvieciacca vokny dy nikoha za imi» Уладзіміра Арлова, таксама выходзілі лацінкай.",
+            "lat": "Pačatak 1990-ch — reniesans biełaruskaj łacinki. Razmovy pra pieravod dakumientacyi ŭžo nie idzie, ale jaje aktyŭna vykarystoŭvajuć u kaściole. Taksama paŭstaje moda siarod nacyjanalnaj kulturnaj tusoŭki. Majo pakaleńnie, skažam, sutyknułasia z łacinkaj praz «Pašpart hramadzianina N.R.M.» dy «Try čarapachi». Nastupnaje – praz Akute. Asobnyja litaraturnyja tvory, jak «Śvieciacca vokny dy nikoha za imi» Uładzimira Arłova, taksama vychodzili łacinkaj."
+        },
+        {
+            "name": "Paragraph 29",
+            "disabled": "zjaŭlacca or źjaŭlacca",
+            "cyr_nar": "Праз N.R.M. процьма беларускай моладзі даведалася пра беларускую лацінку як з’яву. Вокладка альбома N.R.M.",
+            "lat": "Praz N.R.M. proćma biełaruskaj moładzi daviedałasia pra biełaruskuju łacinku jak zjavu. Vokładka alboma N.R.M."
+        },
+        {
+            "name": "Paragraph 30",
+            "disabled": "zjaŭlacca or źjaŭlacca",
+            "cyr_nar": "Афіцыйная ўлада не змагалася і не падтрымлівала лацінку: яна яе не заўважала, як і беларускую мову агулам. Але калі ў мінскім метро з’явілася Plošča Franciška Bahuševiča ды іншыя назвы ў варыянце транслітарацыі, а за імі падцягнуліся надпісы на ўказальніках у цэнтрах гарадоў, падалося нават, што лацінка вяртаецца. Прынамсі — як альтэрнатыўны варыянт, моўны масток на Захад.",
+            "lat": "Aficyjnaja ŭłada nie zmahałasia i nie padtrymlivała łacinku: jana jaje nie zaŭvažała, jak i biełaruskuju movu ahułam. Ale kali ŭ minskim mietro zjaviłasia Plošča Franciška Bahuševiča dy inšyja nazvy ŭ varyjancie tranślitaracyi, a za imi padciahnulisia nadpisy na ŭkazalnikach u centrach haradoŭ, padałosia navat, što łacinka viartajecca. Prynamsi — jak alternatyŭny varyjant, moŭny mastok na Zachad."
+        },
+        {
+            "name": "Paragraph 31",
+            "cyr_nar": "Лацінка. Цывілізацыйны выбар",
+            "lat": "Łacinka. Cyvilizacyjny vybar"
+        },
+        {
+            "name": "Paragraph 32",
+            "cyr_nar": "Сёння відавочна, што не толькі мова, але і алфавіт — гэта палітыка. Калі ўлады арыентуюцца на Маскву, то мірыцца з лацінкай не будуць: як у часы СССР. З іншага боку, ніякая ўлада не вечная і тое самае пытанне можа вырашыцца палітычна ў цалкам супрацьлеглы бок. Гэтак зрабілі ў Казахстане яшчэ пры Назарбаеве: перавялі казахскую мову на лацінку, што выклікала шал у Маскве.",
+            "lat": "Siońnia vidavočna, što nie tolki mova, ale i ałfavit — heta palityka. Kali ŭłady aryjentujucca na Maskvu, to mirycca z łacinkaj nie buduć: jak u časy SSSR. Ź inšaha boku, nijakaja ŭłada nie viečnaja i toje samaje pytańnie moža vyrašycca palityčna ŭ całkam supraćlehły bok. Hetak zrabili ŭ Kazachstanie jašče pry Nazarbajevie: pieraviali kazachskuju movu na łacinku, što vyklikała šał u Maskvie."
+        },
+        {
+            "name": "Paragraph 33",
+            "cyr_nar": "У гісторыі багата падобных выпадкаў. У Ізраілі доўга трывала дыскусія: іўрыт ці ідыш. На ідышы размаўляла абсалютная большасць яўрэяў, якія выжылі пасля Халакосту, але палітычна было вырашана — іўрыт. З цяжкасцямі, але перавучыліся. Ужо згаданы намі Каміль Атацюрк, турэцкі лідар 1920-х, таксама праводзіў свае культурныя рэформы потам і кроўю: суайчыннікі не хацелі пераходзіць на лацінку, але Атацюрк даціснуў пытанне, каб зрабіць дзяржаву больш еўрапейскай.",
+            "lat": "U historyi bahata padobnych vypadkaŭ. U Izraili doŭha tryvała dyskusija: iŭryt ci idyš. Na idyšy razmaŭlała absalutnaja bolšaść jaŭrejaŭ, jakija vyžyli paśla Chałakostu, ale palityčna było vyrašana — iŭryt. Ź ciažkaściami, ale pieravučylisia. Užo zhadany nami Kamil Ataciurk, turecki lidar 1920-ch, taksama pravodziŭ svaje kulturnyja reformy potam i kroŭju: suajčyńniki nie chacieli pierachodzić na łacinku, ale Ataciurk dacisnuŭ pytańnie, kab zrabić dziaržavu bolš jeŭrapiejskaj."
+        },
+        {
+            "name": "Paragraph 34",
+            "cyr_nar": "Сёння, як мінімум на ўзроўні дыяспары, лацінка зноў ажывае: ёсць ужо згаданая адпаведная версія самага папулярнага беларускамоўнага рэсурсу «Наша Ніва», ёсць цэлы беларускамоўны сегмент у сацыяльных сетках лацінкай. Урэшце, Батальён, пазней — Полк Каліноўскага, які ваюе ва Украіне, таксама карыстаецца лацінкай — мовай «Mużyckaj praudy».",
+            "lat": "Siońnia, jak minimum na ŭzroŭni dyjaspary, łacinka znoŭ ažyvaje: jość užo zhadanaja adpaviednaja viersija samaha papularnaha biełaruskamoŭnaha resursu «Naša Niva», jość ceły biełaruskamoŭny siehmient u sacyjalnych sietkach łacinkaj. Urešcie, Bataljon, paźniej — Połk Kalinoŭskaha, jaki vajuje va Ukrainie, taksama karystajecca łacinkaj — movaj «Mużyckaj praudy»."
+        },
+        {
+            "name": "Paragraph 35",
+            "cyr_nar": "Сімволіка Батальёна / Палка Каліноўскага таксама аздобленая лацінкай. Фота: Наша Ніва / nn.by",
+            "lat": "Simvolika Bataljona / Pałka Kalinoŭskaha taksama azdoblenaja łacinkaj. Fota: Naša Niva / nn.by"
+        },
+        {
+            "name": "Paragraph 36",
+            "cyr_nar": "Відавочна, што лацінка не толькі нікуды не знікне, але і мае чарговы гістарычны шанец стаць калі не дамінуючым, то дадатковым алфавітам нашай мовы — альтэрнатыўным. Гэта не толькі спрашчае камунікацыю з Заходнім светам, але і стае цывілізацыйным выбарам беларусаў. Урэшце, ніхто пакуль не патлумачыў, што кепскага ў тым, каб дзеці ў школах вучылі ад старту і кірыліцу, і лацінку — асабліва ў нашым глабальным свеце.",
+            "lat": "Vidavočna, što łacinka nie tolki nikudy nie źniknie, ale i maje čarhovy histaryčny šaniec stać kali nie daminujučym, to dadatkovym ałfavitam našaj movy — alternatyŭnym. Heta nie tolki spraščaje kamunikacyju z Zachodnim śvietam, ale i staje cyvilizacyjnym vybaram biełarusaŭ. Urešcie, nichto pakul nie patłumačyŭ, što kiepskaha ŭ tym, kab dzieci ŭ škołach vučyli ad startu i kirylicu, i łacinku — asabliva ŭ našym hłabalnym śviecie."
+        },
+        {
+            "name": "Paragraph 37",
+            "cyr_nar": "Алесь Кіркевіч",
+            "lat": "Aleś Kirkievič"
+        }
+    ]
+}

--- a/tests/test_1.json
+++ b/tests/test_1.json
@@ -1,15 +1,21 @@
 {
   "tests": [
     {
-      "name": "Test case name",
+      "name": "Alphabet",
+      "cyr_taras": "Аа Бб Цц Цьць Чч Дд Дз дз Дзь дзь Дж дж Ээ Фф Гг Х х Іі Йй Кк Льль Лл Мм Нн Ньнь Оо Пп Рр Сс Сьсь Шш Тт Уу Ўў Вв Ыы Зз Зьзь Жж",
+      "lat": "Aa Bb Cc Ćć Čč Dd Dz dz Dź dź Dž dž Ee Ff Hh Ch ch Ii Jj Kk Ll Łł Mm Nn Ńń Oo Pp Rr Ss Śś Šš Tt Uu Ŭŭ Vv Yy Zz Źź Žž"
+    },
+    {
+      "name": "Snow",
       "cyr_nar": "снег",
       "cyr_taras": "сьнег",
       "lat": "śnieh"
     },
     {
-      "name": "Alphabet",
-      "cyr_taras": "Аа Бб Цц Цьць Чч Дд Дз дз Дзь дзь Дж дж Ээ Фф Гг Х х Іі Йй Кк Льль Лл Мм Нн Ньнь Оо Пп Рр Сс Сьсь Шш Тт Уу Ўў Вв Ыы Зз Зьзь Жж",
-      "lat": "Aa Bb Cc Ćć Čč Dd Dz dz Dź dź Dž dž Ee Ff Hh Ch ch Ii Jj Kk Ll Łł Mm Nn Ńń Oo Pp Rr Ss Śś Šš Tt Uu Ŭŭ Vv Yy Zz Źź Žž"
+      "name": "Appear",
+      "disabled": "zjaŭlacca or źjaŭlacca",
+      "cyr_taras": "з'яўляцца",
+      "lat": "zjaŭlacca"
     }
   ]
 }


### PR DESCRIPTION
Article: https://palatno.media/bielaruskaja-lacinka/

Tests are split into one paragraph == one test. 

* Added a way to disable tests using `"disabled"` property that contains commen why it's disabled. 
* Added Narkamauka => Lacinka converter that calls Tarask => Lac. In future we'll probably split into two steps.
* Fixed `&nbsp;` bug in the converter.
* Added python types.